### PR TITLE
Add support for multiple statements

### DIFF
--- a/proca.py
+++ b/proca.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from math import *
 import cmath
 import sys
+import ast
 
 # Truncation to arbitrary width unsigned integer
 def u(width, value):
@@ -33,17 +34,24 @@ def i64(value):
     return i(64, value)
 
 try:
-    result = eval(" ".join(sys.argv[2:]))
-    radix = sys.argv[1]
-    if radix == "hex":
-        result = hex(int(result))
-    if radix == "binary":
-        result = bin(int(result))
-    if radix == "octal":
-        result = oct(int(result))
-    result = str(result)
+    program = " ".join(sys.argv[2:])
+    code_block = ast.parse(program)
+    ends_with_expression = isinstance(code_block.body[-1], ast.Expr)
+    if ends_with_expression:
+        expression = ast.Expression(code_block.body.pop().value)
+        exec(compile(code_block, filename='<procapy>', mode='exec'))
+        result = eval(compile(expression, filename='<procapy>', mode='eval'))
+        if result is not None:
+            radix = sys.argv[1]
+            if radix == "hex":
+                result = hex(int(result))
+            if radix == "binary":
+                result = bin(int(result))
+            if radix == "octal":
+                result = oct(int(result))
+            result = str(result)
+            print(result, end='')
+    else:
+        exec(program)
 except:
-    result = sys.exc_info()[0].__name__ + ": " + str(sys.exc_info()[1])
-
-# Print result as decimal
-print(result, end="")
+    print(sys.exc_info()[0].__name__ + ": " + str(sys.exc_info()[1]), end='')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ function process(radix: string, proca_path: string)
                     if (!selection.isEmpty)
                     {
                         let expression = document.getText(selection).trim();
-                        if (selection.isSingleLine && expression.length > 0)
+                        if (expression.length > 0)
                         {
                             let result = evaluate(expression, radix, n, proca_path, python_path);
                             builder.replace(selection, result);


### PR DESCRIPTION
If the statements ends with a expression the output of it handled like
before, but otherwise print statements are needed to make useful output.